### PR TITLE
Update URL and required colcon versions

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ name = colcon-spawn-shell
 version = attr: colcon_spawn_shell.__version__
 description-file =
     README.rst
-url = http://github.com/sloretz/colcon-spawn-shell
+url = http://github.com/colcon/colcon-spawn-shell
 license = Apache License, Version 2.0
 author = Shane Loretz
 author_email = shane.loretz@gmail.com
@@ -23,8 +23,8 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-  colcon-core
-  colcon-bash
+  colcon-core>=0.2.1
+  colcon-bash>=0.2.0
 
 [options.package_data]
 colcon_spawn_shell.template = *.em


### PR DESCRIPTION
URL change since this repo moved to the colcon org
Requires recent colcon version since the change from prefix.bash to local_setup.bash