### PR TITLE
Make compatible with ShellExtensionPoint version 2.0

### DIFF
--- a/colcon_spawn_shell/spawn_shell.py
+++ b/colcon_spawn_shell/spawn_shell.py
@@ -30,11 +30,11 @@ class SpawnBashShell(ShellExtensionPoint):
 
     def __init__(self):
         super().__init__()
-        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+        satisfies_version(ShellExtensionPoint.EXTENSION_POINT_VERSION, '^2.0')
         if sys.platform == 'win32' and not use_all_shell_extensions:
             raise SkipExtensionException('Not used on Windows systems')
 
-    def create_prefix_script(self, prefix_path, pkg_names, merge_install):
+    def create_prefix_script(self, prefix_path, merge_install):
         # Use parent of prefix_path to display a pretty workspace name
         workspace_name = 'unknown'
         if len(prefix_path.parts) >= 2:

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,8 +24,8 @@ classifiers =
 zip_safe = False
 packages = find:
 install_requires =
-  colcon-core>=0.2.1
-  colcon-bash>=0.2.0
+  colcon-core>=0.3.1
+  colcon-bash>=0.3.0
 
 [options.package_data]
 colcon_spawn_shell.template = *.em


### PR DESCRIPTION
In colcon/colcon-core#70, the version of ShellExtensionPoint was bumped and a function signature changed. This should update this package to be compatible (I was receiving an error when doing a source install of bouncy)