### PR TITLE
Update deb platforms for release

### DIFF
--- a/publish-python.yaml
+++ b/publish-python.yaml
@@ -10,5 +10,6 @@ artifacts:
           distributions:
             - ubuntu:focal
             - ubuntu:jammy
-            - debian:bullseye
+            - ubuntu:noble
             - debian:bookworm
+            - debian:trixie

--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,5 +1,5 @@
 [colcon-spawn-shell]
 No-Python2:
 Depends3: python3-colcon-core (>= 0.12.0), python3-colcon-bash (>= 0.3.0)
-Suite: focal jammy bullseye bookworm
+Suite: focal jammy noble bookworm trixie
 X-Python3-Version: >= 3.6


### PR DESCRIPTION
Added:
* Ubuntu Noble (24.04 LTS pre-release)
* Debian Trixie (testing)

Dropped:
* Debian Bullseye (oldstable)

Retained:
* Debian Bookworm (stable)
* Ubuntu Focal (20.04 LTS)
* Ubuntu Jammy (22.04 LTS)